### PR TITLE
Feature/entry rename and sorting improvements

### DIFF
--- a/Editor/CustomEditors/PaletteEntryDrawer.cs
+++ b/Editor/CustomEditors/PaletteEntryDrawer.cs
@@ -58,6 +58,14 @@ namespace RoyTheunissen.AssetPalette.CustomEditors
             float height = LabelStyle.CalcHeight(label, position.width);
             return RectExtensions.GetSubRectFromBottom(position, height);
         }
+        
+        public static Rect GetRenameRect(Rect position, string name)
+        {
+            GUIContent label = new GUIContent(name);
+            GUIStyle style = AssetPaletteWindow.GridEntryRenameTextStyle;
+            float height = style.CalcHeight(label, position.width);
+            return RectExtensions.GetSubRectFromBottom(position, height);
+        }
 
         public abstract void OnGUI(Rect position, SerializedProperty property, PaletteEntry entry);
         public abstract void OnListGUI(Rect position, SerializedProperty property, PaletteEntry entry, bool isSelected);
@@ -96,7 +104,7 @@ namespace RoyTheunissen.AssetPalette.CustomEditors
             // NOTE: If an entry is being renamed in the grid view and we ONLY handle the repaint events here, then
             // for some reason the rename text field stops working correctly. Another weird bug. How can the label
             // rect even steal focus? It is not a named control...
-            if (Event.current.type == EventType.Repaint || PaletteEntry.IsEntryBeingRenamed)
+            if ((Event.current.type == EventType.Repaint || PaletteEntry.IsEntryBeingRenamed) && !entry.IsRenaming)
             {
                 GUIContent label = new GUIContent(entry.Name);
                 Rect labelRect = GetLabelRect(position, entry);

--- a/Editor/CustomEditors/PaletteEntryDrawer.cs
+++ b/Editor/CustomEditors/PaletteEntryDrawer.cs
@@ -93,7 +93,10 @@ namespace RoyTheunissen.AssetPalette.CustomEditors
             // NOTE: For some reason, if we don't filter out non-repaint events here then drawing the label will cause
             // the Zoom Level control to lose focus when switching between list view and grid view.
             // Doesn't make sense to me. How can a label steal focus mid-drag?
-            if (Event.current.type == EventType.Repaint)
+            // NOTE: If an entry is being renamed in the grid view and we ONLY handle the repaint events here, then
+            // for some reason the rename text field stops working correctly. Another weird bug. How can the label
+            // rect even steal focus? It is not a named control...
+            if (Event.current.type == EventType.Repaint || PaletteEntry.IsEntryBeingRenamed)
             {
                 GUIContent label = new GUIContent(entry.Name);
                 Rect labelRect = GetLabelRect(position, entry);

--- a/Editor/Windows/AssetPaletteWindowEntryPanel.cs
+++ b/Editor/Windows/AssetPaletteWindowEntryPanel.cs
@@ -64,31 +64,45 @@ namespace RoyTheunissen.AssetPalette.Windows
         }
         
         [NonSerialized] private static GUIStyle cachedGridEntryRenameTextStyle;
-        [NonSerialized] private static GUIStyle cachedListEntryRenameTextStyle;
-        [NonSerialized] private static bool didCacheEntryRenameTextStyle;
-        private GUIStyle EntryRenameTextStyle
+        [NonSerialized] private static bool didCacheGridEntryRenameTextStyle;
+        public static GUIStyle GridEntryRenameTextStyle
         {
             get
             {
-                if (!didCacheEntryRenameTextStyle)
+                if (!didCacheGridEntryRenameTextStyle)
                 {
-                    didCacheEntryRenameTextStyle = true;
+                    didCacheGridEntryRenameTextStyle = true;
                     cachedGridEntryRenameTextStyle = new GUIStyle(EditorStyles.textField)
                     {
                         wordWrap = true,
                         alignment = TextAnchor.LowerCenter,
                     };
-
+                }
+                return cachedGridEntryRenameTextStyle;
+            }
+        }
+        
+        [NonSerialized] private static GUIStyle cachedListEntryRenameTextStyle;
+        [NonSerialized] private static bool didCacheListEntryRenameTextStyle;
+        private GUIStyle ListEntryRenameTextStyle
+        {
+            get
+            {
+                if (!didCacheListEntryRenameTextStyle)
+                {
+                    didCacheListEntryRenameTextStyle = true;
                     cachedListEntryRenameTextStyle = new GUIStyle(EditorStyles.textField)
                     {
                         wordWrap = true,
                         alignment = TextAnchor.MiddleLeft
                     };
                 }
-
-                return ShouldDrawListView ? cachedListEntryRenameTextStyle : cachedGridEntryRenameTextStyle;
+                return cachedListEntryRenameTextStyle;
             }
         }
+
+        private GUIStyle EntryRenameTextStyle =>
+            ShouldDrawListView ? ListEntryRenameTextStyle : GridEntryRenameTextStyle;
         
         [NonSerialized] private PaletteEntry entryBelowCursorOnMouseDown;
 
@@ -364,10 +378,13 @@ namespace RoyTheunissen.AssetPalette.Windows
             Rect entryContentsRect = rect;
             SerializedProperty entryProperty = SelectedFolderEntriesSerializedProperty.GetArrayElementAtIndex(index);
 
+            PaletteDrawing.DrawGridEntry(entryContentsRect, entryProperty, entry);
+            
             if (entry.IsRenaming)
-                DrawRenameEntry(entryProperty, entryContentsRect);
-            else
-                PaletteDrawing.DrawGridEntry(entryContentsRect, entryProperty, entry);
+            {
+                Rect labelRect = PaletteEntryDrawerBase.GetRenameRect(entryContentsRect, renameText);
+                DrawRenameEntry(entryProperty, labelRect);
+            }
         }
 
         private void PurgeInvalidEntries(int index)
@@ -379,16 +396,19 @@ namespace RoyTheunissen.AssetPalette.Windows
             }
         }
 
-        private void DrawRenameEntry(SerializedProperty entryProperty, Rect entryContentsRect)
+        private void DrawRenameEntry(SerializedProperty entryProperty, Rect labelRect)
         {
             string renameControlId = GetRenameControlId(entryProperty);
             GUI.SetNextControlName(renameControlId);
-            renameText = EditorGUI.TextField(entryContentsRect, renameText, EntryRenameTextStyle);
-            GUI.FocusControl(renameControlId);
+            renameText = EditorGUI.TextField(labelRect, renameText, EntryRenameTextStyle);
+            EditorGUI.FocusTextInControl(renameControlId);
         }
 
         private void HandleEntrySelection(int index, Rect rect, PaletteEntry entry, ref bool didClickASpecificEntry)
         {
+            if (IsRenaming)
+                return;
+            
             // Allow this entry to be selected by clicking it.
             bool isMouseOnEntry = rect.Contains(Event.current.mousePosition) && isMouseInEntriesPanel;
             bool wasAlreadySelected = entriesSelected.Contains(entry);

--- a/Editor/Windows/AssetPaletteWindowEntryPanel.cs
+++ b/Editor/Windows/AssetPaletteWindowEntryPanel.cs
@@ -25,10 +25,15 @@ namespace RoyTheunissen.AssetPalette.Windows
         
         private SortModes SortMode
         {
-            get => (SortModes)EditorPrefs.GetInt(EntriesSortModeEditorPref);
+            get
+            {
+                if (!EditorPrefs.HasKey(EntriesSortModeEditorPref))
+                    SortMode = SortModes.Alphabetical;
+                return (SortModes)EditorPrefs.GetInt(EntriesSortModeEditorPref);
+            }
             set => EditorPrefs.SetInt(EntriesSortModeEditorPref, (int)value);
         }
-        
+
         [NonSerialized] private bool didCacheSelectedFolderEntriesSerializedProperty;
         [NonSerialized] private SerializedProperty cachedSelectedFolderEntriesSerializedProperty;
         private SerializedProperty SelectedFolderEntriesSerializedProperty

--- a/Editor/Windows/AssetPaletteWindowEntryPanel.cs
+++ b/Editor/Windows/AssetPaletteWindowEntryPanel.cs
@@ -682,6 +682,12 @@ namespace RoyTheunissen.AssetPalette.Windows
                 SerializedProperty customNameProperty = entryBeingRenamedProperty.FindPropertyRelative("customName");
                 customNameProperty.stringValue = renameText;
                 CurrentCollectionSerializedObject.ApplyModifiedProperties();
+                
+                // Also sort the collection. Make sure to do this AFTER we apply the rename, otherwise the sort will
+                // be based on the old name! Don't worry, doing this in a separate Apply doesn't cause a separate Undo
+                CurrentCollectionSerializedObject.Update();
+                SortEntriesInSerializedObject();
+                CurrentCollectionSerializedObject.ApplyModifiedProperties();
             }
 
             PaletteEntry.CancelRename();

--- a/Runtime/PaletteEntry.cs
+++ b/Runtime/PaletteEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using RoyTheunissen.AssetPalette.Runtime;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -31,6 +32,8 @@ namespace RoyTheunissen.AssetPalette
         public bool IsRenaming => entryCurrentlyRenaming == this;
         public static bool IsEntryBeingRenamed => entryCurrentlyRenaming != null;
 
+        protected virtual PaletteEntrySortPriorities SortPriority => PaletteEntrySortPriorities.Default;
+
         public abstract void Open();
 
         public void StartRename()
@@ -50,6 +53,12 @@ namespace RoyTheunissen.AssetPalette
 
         public int CompareTo(PaletteEntry other)
         {
+            // First check if the sort priorities are different.
+            int priorityOrder = SortPriority.CompareTo(other.SortPriority);
+            if (priorityOrder != 0)
+                return priorityOrder;
+            
+            // Entries with the same sort priority are sorted by name.
             return String.Compare(Name, other.Name, StringComparison.Ordinal);
         }
 

--- a/Runtime/PaletteEntrySortPriorities.cs
+++ b/Runtime/PaletteEntrySortPriorities.cs
@@ -5,6 +5,8 @@ namespace RoyTheunissen.AssetPalette.Runtime
     /// </summary>
     public enum PaletteEntrySortPriorities 
     {
+        Shortcuts,
+        Macros,
         Default,
     }
 }

--- a/Runtime/PaletteEntrySortPriorities.cs
+++ b/Runtime/PaletteEntrySortPriorities.cs
@@ -1,0 +1,10 @@
+namespace RoyTheunissen.AssetPalette.Runtime
+{
+    /// <summary>
+    /// Helps you define in what order entries are sorted.
+    /// </summary>
+    public enum PaletteEntrySortPriorities 
+    {
+        Default,
+    }
+}

--- a/Runtime/PaletteEntrySortPriorities.cs.meta
+++ b/Runtime/PaletteEntrySortPriorities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4aee324e7771fcd44a8bf44cea348fb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/PaletteMacro.cs
+++ b/Runtime/PaletteMacro.cs
@@ -29,6 +29,8 @@ namespace RoyTheunissen.AssetPalette.Runtime
 
         public override bool IsValid => script != null && !string.IsNullOrEmpty(methodName);
 
+        protected override PaletteEntrySortPriorities SortPriority => PaletteEntrySortPriorities.Macros;
+
         public PaletteMacro(TextAsset script, string methodName)
         {
             this.script = script;

--- a/Runtime/PaletteSelectionShortcut.cs
+++ b/Runtime/PaletteSelectionShortcut.cs
@@ -65,6 +65,8 @@ namespace RoyTheunissen.AssetPalette.Runtime
             }
         }
 
+        protected override PaletteEntrySortPriorities SortPriority => PaletteEntrySortPriorities.Shortcuts;
+
         public override void Open()
         {
             if (Selection.Length == 0)


### PR DESCRIPTION
- Renaming entries in the grid view now looks more like it does in the list view
- Fixed bug that caused not being able to rename entries in the grid view correctly
- Fixed being prompted to add macros when dragging in multiple scripts
- Renamed entries are now re-ordered as well
- Shortcuts and macros are now always ordered before assets, which is more organized