### PR TITLE
Feature/project specific editorprefs

### DIFF
--- a/Editor/Windows/AssetPaletteWindow.cs
+++ b/Editor/Windows/AssetPaletteWindow.cs
@@ -14,12 +14,24 @@ namespace RoyTheunissen.AssetPalette.Windows
     /// </summary>
     public partial class AssetPaletteWindow : EditorWindow, IHasCustomMenu
     {
-        private const string EditorPrefPrefix = "RoyTheunissen/PrefabPalette/";
-        private const string CurrentCollectionGUIDEditorPref = EditorPrefPrefix + "CurrentCollectionGUID";
-        private const string FolderPanelWidthEditorPref = EditorPrefPrefix + "FolderPanelWidth";
-        private const string ZoomLevelEditorPref = EditorPrefPrefix + "ZoomLevel";
-        private const string SelectedFolderIndexEditorPref = EditorPrefPrefix + "SelectedFolderIndex";
-        private const string EntriesSortModeEditorPref = EditorPrefPrefix + "EntriesSortMode";
+        private static string ProjectName
+        {
+            get
+            {
+                string[] sections = Application.dataPath.Split(
+                    Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                
+                // The name of the project is the dataPath i.e. Project/Assets and then go up a directory.
+                return sections[^2];
+            }
+        }
+        
+        private static string EditorPrefPrefix => $"RoyTheunissen/PrefabPalette/{ProjectName}/";
+        private static string CurrentCollectionGUIDEditorPref => EditorPrefPrefix + "CurrentCollectionGUID";
+        private static string FolderPanelWidthEditorPref => EditorPrefPrefix + "FolderPanelWidth";
+        private static string ZoomLevelEditorPref => EditorPrefPrefix + "ZoomLevel";
+        private static string SelectedFolderIndexEditorPref => EditorPrefPrefix + "SelectedFolderIndex";
+        private static string EntriesSortModeEditorPref => EditorPrefPrefix + "EntriesSortMode";
 
         private const string FolderDragGenericDataType = "AssetPaletteFolderDrag";
         private const string EntryDragGenericDataType = "AssetPaletteEntryDrag";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.roytheunissen.assetpalette",
   "displayName": "Asset Palette",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "unity": "2021.3",
   "description": "Allows you to quickly organize assets for certain workflows, such as organizing prefabs for level design.",
   "keywords": [


### PR DESCRIPTION
- Made editor prefs project-specific so that you can switch between different projects that have the Asset Palette and not have incorrect settings / lose settings.