### PR TITLE
Feature/selection improvements

### DIFF
--- a/Editor/Windows/AssetPaletteWindowFolderPanel.cs
+++ b/Editor/Windows/AssetPaletteWindowFolderPanel.cs
@@ -80,6 +80,8 @@ namespace RoyTheunissen.AssetPalette.Windows
             get => EditorPrefs.GetString(SelectedFolderReferenceIdPathEditorPref);
             set => EditorPrefs.SetString(SelectedFolderReferenceIdPathEditorPref, value);
         }
+        
+        private int FolderCount => FoldersSerializedProperty.arraySize;
 
         [NonSerialized] private bool didCacheSelectedFolderSerializedProperty;
         [NonSerialized] private SerializedProperty cachedSelectedFolderSerializedProperty;
@@ -194,7 +196,7 @@ namespace RoyTheunissen.AssetPalette.Windows
 
         private void EnsureFolderExists()
         {
-            if (CurrentCollection.Folders.Count > 0)
+            if (FolderCount > 0)
                 return;
             
             // Make sure there is at least one folder.
@@ -535,7 +537,7 @@ namespace RoyTheunissen.AssetPalette.Windows
         
         private void RemoveFolder(SerializedProperty folderProperty)
         {
-            if (folderProperty == null || !HasCollection || CurrentCollection.Folders.Count <= 1)
+            if (folderProperty == null || !HasCollection || FolderCount <= 1)
                 return;
 
             SerializedProperty listProperty = folderProperty.GetParent();

--- a/Editor/Windows/AssetPaletteWindowFooter.cs
+++ b/Editor/Windows/AssetPaletteWindowFooter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -17,6 +18,8 @@ namespace RoyTheunissen.AssetPalette.Windows
             }
             set => EditorPrefs.SetFloat(ZoomLevelEditorPref, value);
         }
+        
+        private List<Object> entryAssetsWhosePathToShow = new List<Object>();
 
         private bool IsZoomLevelFocused => GUI.GetNameOfFocusedControl() == ZoomLevelControlName;
         
@@ -33,6 +36,29 @@ namespace RoyTheunissen.AssetPalette.Windows
                 GUILayout.FlexibleSpace();
                 EditorGUILayout.BeginHorizontal();
                 {
+                    // Draw the asset path of the first asset that is selected. That's how the Project View does it.
+                    foreach (PaletteEntry paletteEntry in entriesSelected)
+                    {
+                        entryAssetsWhosePathToShow.Clear();
+                        paletteEntry.GetAssetsToSelect(ref entryAssetsWhosePathToShow);
+                        if (entryAssetsWhosePathToShow.Count > 0)
+                        {
+                            Object objectToShow = entryAssetsWhosePathToShow[0];
+                            string path = AssetDatabase.GetAssetPath(objectToShow);
+                            Texture icon = 
+                                //EditorGUIUtility.GetIconForObject(objectToShow)
+                                AssetDatabase.GetCachedIcon(path)
+                                ;
+                            GUIContent guiContent = new GUIContent(path, icon);
+                            //EditorGUILayout.LabelField(guiContent);
+                            EditorGUIUtility.SetIconSize(Vector2.one * 14);
+                            Rect pathRect = GUILayoutUtility.GetRect(guiContent, EditorStyles.label);
+                            EditorGUI.LabelField(pathRect, guiContent);
+                            EditorGUIUtility.SetIconSize(Vector2.zero);
+                            break;
+                        }
+                    }
+                    
                     GUILayout.FlexibleSpace();
                     Rect zoomLevelRect = GUILayoutUtility.GetRect(80, EditorGUIUtility.singleLineHeight);
 

--- a/Runtime/PaletteAsset.cs
+++ b/Runtime/PaletteAsset.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -57,13 +58,9 @@ namespace RoyTheunissen.AssetPalette
 #endif // UNITY_EDITOR
         }
 
-        public override void SelectAsset()
+        public override void GetAssetsToSelect(ref List<Object> selection)
         {
-            base.SelectAsset();
-            
-#if UNITY_EDITOR
-            Selection.activeObject = asset;
-#endif // UNITY_EDITOR
+            selection.Add(asset);
         }
 
         public override void Refresh()

--- a/Runtime/PaletteEntry.cs
+++ b/Runtime/PaletteEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using RoyTheunissen.AssetPalette.Runtime;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -35,10 +36,8 @@ namespace RoyTheunissen.AssetPalette
         protected virtual PaletteEntrySortPriorities SortPriority => PaletteEntrySortPriorities.Default;
 
         public abstract void Open();
-        
-        public virtual void SelectAsset()
-        {
-        }
+
+        public abstract void GetAssetsToSelect(ref List<Object> selection);
 
         public void StartRename()
         {

--- a/Runtime/PaletteMacro.cs
+++ b/Runtime/PaletteMacro.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using RoyTheunissen.AssetPalette.Extensions;
 using UnityEngine;
@@ -76,13 +77,9 @@ namespace RoyTheunissen.AssetPalette.Runtime
 #endif // UNITY_EDITOR
         }
         
-        public override void SelectAsset()
+        public override void GetAssetsToSelect(ref List<Object> selection)
         {
-            base.SelectAsset();
-            
-#if UNITY_EDITOR
-            UnityEditor.Selection.activeObject = script;
-#endif // UNITY_EDITOR
+            selection.Add(script);
         }
 
         public static bool CanCallMethodForMacro(MethodInfo methodInfo)

--- a/Runtime/PaletteSelectionShortcut.cs
+++ b/Runtime/PaletteSelectionShortcut.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -85,11 +86,9 @@ namespace RoyTheunissen.AssetPalette.Runtime
 #endif // UNITY_EDITOR
         }
         
-        public override void SelectAsset()
+        public override void GetAssetsToSelect(ref List<Object> selection)
         {
-            base.SelectAsset();
-            
-            Open();
+            selection.AddRange(Selection);
         }
 
         public PaletteSelectionShortcut(Object[] selection)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.roytheunissen.assetpalette",
   "displayName": "Asset Palette",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "unity": "2020.3",
   "description": "Allows you to quickly organize assets for certain workflows, such as organizing prefabs for level design.",
   "keywords": [


### PR DESCRIPTION
![image](https://github.com/RoyTheunissen/Asset-Palette/assets/3997055/fa93c03d-7e17-48e9-9699-5f542d3cc8d6)

- Selecting something in the Asset Palette now selects it in the Project View too. This makes it easier to just look at stuff.
- The footer now shows the path of the asset that is currently selected, like how the Project View does
- Fixed newly created palettes getting two default folders