### PR TITLE
add: using cache editor for preview

### DIFF
--- a/Editor/Entries/PaletteAsset.cs
+++ b/Editor/Entries/PaletteAsset.cs
@@ -33,6 +33,8 @@ namespace RoyTheunissen.AssetPalette
         public override bool IsValid => Asset != null;
 
         protected override string DefaultName => Asset.name;
+
+        private Editor cachedEditor;
         
         [NonSerialized] private Texture2D cachedPreviewTexture;
         [NonSerialized] private bool didCachePreviewTexture;
@@ -45,10 +47,9 @@ namespace RoyTheunissen.AssetPalette
                     didCachePreviewTexture = true;
 
                     string path = AssetDatabase.GetAssetPath(Asset.GetInstanceID());
-                    
-                    Editor editor = Editor.CreateEditor(Asset, null);
-                    cachedPreviewTexture = editor.RenderStaticPreview(path, null, TextureSize, TextureSize);
-                    Object.DestroyImmediate(editor);
+
+                    Editor.CreateCachedEditor(Asset, null, ref cachedEditor);
+                    cachedPreviewTexture = cachedEditor.RenderStaticPreview(path, null, TextureSize, TextureSize);
                 }
                 return cachedPreviewTexture;
             }


### PR DESCRIPTION
Update the preview to use the `CreateEditorCache` in theory this will create a lot less editor since most of the times we reuse the same with a different context. 